### PR TITLE
Remove application properties

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,11 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.kazy.lib">
-
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-                 android:supportsRtl="true"
-            >
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
Apps which is using this app are need to overwrite `allowBackup` and `supportsRtl`. So I recommend to remove those properties.
