### PR TITLE
Calculate offset after path#close

### DIFF
--- a/lib/src/main/java/com/kazy/fontdrawable/FontDrawable.java
+++ b/lib/src/main/java/com/kazy/fontdrawable/FontDrawable.java
@@ -51,8 +51,8 @@ public class FontDrawable extends Drawable {
         final Path path = createTextPathBase();
         RectF textBounds = createTextBounds(path);
         applyPadding(path, textBounds, createPaddingBounds());
-        applyOffset(path, textBounds);
         path.close();
+        applyOffset(path, textBounds);
         return path;
     }
 


### PR DESCRIPTION
close: https://github.com/kazy1991/FontDrawable/issues/6

# Context

Path has `isSimplePath` flag(hidden). 

# Problem

When `isSimplePath` is false, Path does not apply offset.

https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/graphics/java/android/graphics/Path.java#724

# Solution

Path#close can change `isSimplePath` flag from `false` to `true`.

https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/graphics/java/android/graphics/Path.java#499